### PR TITLE
Adjustment of Stagnation Restart

### DIFF
--- a/opendse-optimization/src/main/java/net/sf/opendse/optimization/OptimizationModule.java
+++ b/opendse-optimization/src/main/java/net/sf/opendse/optimization/OptimizationModule.java
@@ -46,8 +46,9 @@ public class OptimizationModule extends ProblemModule {
 	protected boolean usePreprocessing = true;
 
 	protected boolean stagnationRestartEnabled = true;
-	@Constant(value = "preprocessing", namespace = SATConstraints.class)
+	
 	@Required(property = "stagnationRestartEnabled", elements = { "TRUE" })
+	@Constant(value = "maximalNumberStagnatingGenerations", namespace = StagnationRestart.class)
 	protected int maximalNumberStagnatingGenerations = 20;
 
 	@Constant(value = "variableorder", namespace = SATCreatorDecoder.class)

--- a/opendse-optimization/src/main/java/net/sf/opendse/optimization/OptimizationModule.java
+++ b/opendse-optimization/src/main/java/net/sf/opendse/optimization/OptimizationModule.java
@@ -30,6 +30,7 @@ import net.sf.opendse.optimization.constraints.SpecificationRouterConstraints;
 import net.sf.opendse.optimization.encoding.Encoding.RoutingEncoding;
 
 import org.opt4j.core.config.annotations.Parent;
+import org.opt4j.core.config.annotations.Required;
 import org.opt4j.core.problem.ProblemModule;
 import org.opt4j.core.start.Constant;
 import org.opt4j.viewer.VisualizationModule;
@@ -40,14 +41,18 @@ import com.google.inject.multibindings.Multibinder;
 public class OptimizationModule extends ProblemModule {
 
 	protected RoutingEncoding routingEncoding = RoutingEncoding.FLOW;
-	
+
 	@Constant(value = "preprocessing", namespace = SATConstraints.class)
 	protected boolean usePreprocessing = true;
-	
-	
+
+	protected boolean stagnationRestartEnabled = true;
+	@Constant(value = "preprocessing", namespace = SATConstraints.class)
+	@Required(property = "stagnationRestartEnabled", elements = { "TRUE" })
+	protected int maximalNumberStagnatingGenerations = 20;
+
 	@Constant(value = "variableorder", namespace = SATCreatorDecoder.class)
 	protected boolean useVariableOrder = true;
-	
+
 	public RoutingEncoding getRoutingEncoding() {
 		return routingEncoding;
 	}
@@ -72,6 +77,22 @@ public class OptimizationModule extends ProblemModule {
 		this.useVariableOrder = useVariableOrder;
 	}
 
+	public boolean isStagnationRestartEnabled() {
+		return stagnationRestartEnabled;
+	}
+
+	public void setStagnationRestartEnabled(boolean stagnationRestartEnabled) {
+		this.stagnationRestartEnabled = stagnationRestartEnabled;
+	}
+
+	public int getMaximalNumberStagnatingGenerations() {
+		return maximalNumberStagnatingGenerations;
+	}
+
+	public void setMaximalNumberStagnatingGenerations(int maximalNumberStagnatingGenerations) {
+		this.maximalNumberStagnatingGenerations = maximalNumberStagnatingGenerations;
+	}
+
 	@Override
 	protected void config() {
 		bindProblem(DesignSpaceExplorationCreator.class, DesignSpaceExplorationDecoder.class,
@@ -90,11 +111,13 @@ public class OptimizationModule extends ProblemModule {
 
 		Multibinder.newSetBinder(binder(), ImplementationEvaluator.class);
 
-		addOptimizerIterationListener(StagnationRestart.class);
-		
+		if (stagnationRestartEnabled) {
+			addOptimizerIterationListener(StagnationRestart.class);
+		}
+
 		bind(RoutingEncoding.class).toInstance(routingEncoding);
 
-		if (useVariableOrder){
+		if (useVariableOrder) {
 			bind(RoutingVariableClassOrder.class).asEagerSingleton();
 		}
 	}

--- a/opendse-optimization/src/test/java/net/sf/opendse/optimization/StagnationRestartTest.java
+++ b/opendse-optimization/src/test/java/net/sf/opendse/optimization/StagnationRestartTest.java
@@ -62,6 +62,10 @@ public class StagnationRestartTest {
 		restart.archive.add(indi1);
 		restart.archive.add(indi2);
 		assertEquals(0, restart.lastUpdate);
+		restart.iterationComplete(5);
+		assertEquals(0, restart.lastUpdate);
+		assertFalse(population.isEmpty());
+		assertFalse(restart.archive.isEmpty());
 		restart.iterationComplete(21);
 		assertEquals(21, restart.lastUpdate);
 		assertTrue(population.isEmpty());

--- a/opendse-optimization/src/test/java/net/sf/opendse/optimization/StagnationRestartTest.java
+++ b/opendse-optimization/src/test/java/net/sf/opendse/optimization/StagnationRestartTest.java
@@ -1,0 +1,71 @@
+package net.sf.opendse.optimization;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.opt4j.core.Individual;
+import org.opt4j.core.Objectives;
+import org.opt4j.core.optimizer.Population;
+
+public class StagnationRestartTest {
+
+	class MockIndividual extends Individual {
+		public MockIndividual(boolean dominated) {
+			super();
+			setObjectives(dominated ? new MockDominatedObjectives() : new MockDominantObjectives());
+		}
+	}
+
+	class MockPopulation extends Population {
+
+	}
+
+	class MockDominatedObjectives extends Objectives {
+		@Override
+		public boolean dominates(Objectives opponent) {
+			return false;
+		}
+	}
+
+	class MockDominantObjectives extends Objectives {
+		@Override
+		public boolean dominates(Objectives opponent) {
+			return true;
+		}
+	}
+
+	@Test
+	public void testNoStagnation() {
+		Population population = new Population();
+		Individual indi1 = new MockIndividual(false);
+		Individual indi2 = new MockIndividual(false);
+		population.add(indi1);
+		population.add(indi2);
+		StagnationRestart restart = new StagnationRestart(population, 20);
+		restart.archive.add(indi1);
+		restart.archive.add(indi2);
+		assertEquals(0, restart.lastUpdate);
+		restart.iterationComplete(21);
+		assertEquals(21, restart.lastUpdate);
+		assertFalse(population.isEmpty());
+		assertFalse(restart.archive.isEmpty());
+	}
+
+	@Test
+	public void testStagnation() {
+		Population population = new Population();
+		Individual indi1 = new MockIndividual(true);
+		Individual indi2 = new MockIndividual(true);
+		population.add(indi1);
+		population.add(indi2);
+		StagnationRestart restart = new StagnationRestart(population, 20);
+		restart.archive.add(indi1);
+		restart.archive.add(indi2);
+		assertEquals(0, restart.lastUpdate);
+		restart.iterationComplete(21);
+		assertEquals(21, restart.lastUpdate);
+		assertTrue(population.isEmpty());
+		assertTrue(restart.archive.isEmpty());
+	}
+
+}


### PR DESCRIPTION
Beside a test and comments for the Stagnation Restart class, the main issue of this commit is that you now can activate whether or not it is bound (before it was bound by default, without letting the user know about it) and you can adjust the number of generations that is considered as a stagnation.