### PR TITLE
Enable integration as gradle subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,11 +140,11 @@ task fatjar(dependsOn: subprojects.jar, type: Jar) {
 }
 
 dependencies {
-	runtime project(':opendse-model')
-	runtime project(':opendse-io')
-	runtime project(':opendse-visualization')
-	runtime project(':opendse-optimization')
-	runtime project(':opendse-realtime')
+	runtime project('opendse-model')
+	runtime project('opendse-io')
+	runtime project('opendse-visualization')
+	runtime project('opendse-optimization')
+	runtime project('opendse-realtime')
 }
 
 jar {

--- a/opendse-generator/build.gradle
+++ b/opendse-generator/build.gradle
@@ -1,3 +1,3 @@
 dependencies {	
-	compile project(':opendse-model')
+	compile parent.project('opendse-model')
 }

--- a/opendse-io/build.gradle
+++ b/opendse-io/build.gradle
@@ -1,5 +1,5 @@
 dependencies {	
-	compile project(':opendse-model')
+	compile parent.project('opendse-model')
 
 	compile group: 'xom',	name: 'xom', 		version: '1.2.5'
 	

--- a/opendse-optimization/build.gradle
+++ b/opendse-optimization/build.gradle
@@ -3,10 +3,17 @@ dependencies {
 	compile parent.project('opendse-io')
 	compile parent.project('opendse-visualization')
 	
-	compile group: 'org.opt4j',	name: 'opt4j-core', 		version: '3.1.4'
-	compile group: 'org.opt4j',	name: 'opt4j-satdecoding', 	version: '3.1.4'
-	compile group: 'org.opt4j',	name: 'opt4j-optimizers', 	version: '3.1.4'
-	compile group: 'org.opt4j',	name: 'opt4j-viewer', 		version: '3.1.4'
+	if ((rootProject.subprojects.findAll { it.name == "opt4j" }).isEmpty()) {
+		compile group: 'org.opt4j',	name: 'opt4j-core', 		version: '3.1.4'
+		compile group: 'org.opt4j',	name: 'opt4j-satdecoding', 	version: '3.1.4'
+		compile group: 'org.opt4j',	name: 'opt4j-optimizers', 	version: '3.1.4'
+		compile group: 'org.opt4j',	name: 'opt4j-viewer', 		version: '3.1.4'
+	} else {	
+		compile project(':opt4j:opt4j-core')
+		compile project(':opt4j:opt4j-satdecoding')
+		compile project(':opt4j:opt4j-optimizers')
+		compile project(':opt4j:opt4j-viewer')
+	}
 
 	testCompile 'junit:junit:4.12'
 }

--- a/opendse-optimization/build.gradle
+++ b/opendse-optimization/build.gradle
@@ -1,7 +1,7 @@
 dependencies {	
-	compile project(':opendse-model')
-	compile project(':opendse-io')
-	compile project(':opendse-visualization')
+	compile parent.project('opendse-model')
+	compile parent.project('opendse-io')
+	compile parent.project('opendse-visualization')
 	
 	compile group: 'org.opt4j',	name: 'opt4j-core', 		version: '3.1.4'
 	compile group: 'org.opt4j',	name: 'opt4j-satdecoding', 	version: '3.1.4'

--- a/opendse-realtime/build.gradle
+++ b/opendse-realtime/build.gradle
@@ -1,10 +1,10 @@
 dependencies {	
 	compile 'net.sf.jmpi:jmpi-main:0.6'
 	compile 'net.sf.jmpi:jmpi-solver-gurobi:0.6'
-	compile project(':opendse-model')
-	compile project(':opendse-visualization')
+	compile parent.project('opendse-model')
+	compile parent.project('opendse-visualization')
 	compile files('libs/gurobi.jar')
 	
-	testCompile project(':opendse-generator')
-	testCompile project(':opendse-optimization')
+	testCompile parent.project('opendse-generator')
+	testCompile parent.project('opendse-optimization')
 }

--- a/opendse-tutorial/build.gradle
+++ b/opendse-tutorial/build.gradle
@@ -2,8 +2,8 @@ import org.apache.tools.ant.filters.*
 import java.util.regex.*
 
 dependencies {	
-	compile project(':opendse-optimization')
-	compile project(':opendse-realtime')
+	compile parent.project('opendse-optimization')
+	compile parent.project('opendse-realtime')
 }
 
 task filterSources(type: Copy) {

--- a/opendse-visualization/build.gradle
+++ b/opendse-visualization/build.gradle
@@ -6,5 +6,9 @@ dependencies {
 
 	compile group: 'net.java.dev.glazedlists',	name: 'glazedlists_java15', 		version: '1.9.0'
 	
-	compile group: 'org.opt4j',	name: 'opt4j-core', 		version: '3.1.4'
+	if ((rootProject.subprojects.findAll { it.name == "opt4j" }).isEmpty()) {
+		compile group: 'org.opt4j',	name: 'opt4j-core', 		version: '3.1.4'
+	} else {
+		compile project(':opt4j:opt4j-core')
+	}
 }

--- a/opendse-visualization/build.gradle
+++ b/opendse-visualization/build.gradle
@@ -1,6 +1,6 @@
 dependencies {	
-	compile project(':opendse-model')
-	compile project(':opendse-io')
+	compile parent.project('opendse-model')
+	compile parent.project('opendse-io')
 	
 	compile group: 'net.sf.jung',	name: 'jung-visualization', 	version: '2.0.1'
 


### PR DESCRIPTION
Changed OpenDSE project to be integratable as a gradle subproject to a top project.
For this purpose, change subproject reference, e.g., to opendse-optimization, to be relative.
Furthermore, if the top project contains a Opt4J subproject, use it to satisfy the Opt4J dependencies required by OpenDSE.