### PR TITLE
Changed the creation of the bounds for the SAT Variable activity

### DIFF
--- a/opendse-optimization/build.gradle
+++ b/opendse-optimization/build.gradle
@@ -9,4 +9,5 @@ dependencies {
 	compile group: 'org.opt4j',	name: 'opt4j-viewer', 		version: '3.1.4'
 
 	testCompile 'junit:junit:4.12'
+	testCompile group: 'org.mockito', name: 'mockito-core', version: '2.22.0'
 }

--- a/opendse-optimization/src/main/java/net/sf/opendse/optimization/SATCreatorDecoder.java
+++ b/opendse-optimization/src/main/java/net/sf/opendse/optimization/SATCreatorDecoder.java
@@ -131,11 +131,47 @@ public class SATCreatorDecoder extends AbstractSATDecoder<Genotype, Implementati
 			// class at list position 1 is assigned the activity interval
 			// between
 			// .2 and .4
-			double lbv = (order.getOrderSize() - order.indexOf(variable) - 1) * 1.0 / order.getOrderSize();
-			double ubv = (order.getOrderSize() - order.indexOf(variable)) * 1.0 / order.getOrderSize();
+			double lbv = getLowerOrderBound(order.getOrderSize(), order.indexOf(variable));
+			double ubv = getUpperOrderBound(order.getOrderSize(), order.indexOf(variable));
 			double prio = lbv + random.nextDouble() * (ubv - lbv);
 			priorities.put(variable, prio);
 		}
+	}
+
+	/**
+	 * Returns the upper bound for the order of the class on the given position of
+	 * the order list.
+	 * 
+	 * @param orderSize  the size of the order list, that is, the number of classes
+	 *                   (not object instances!) that are included in the SAT
+	 *                   genotype
+	 * @param orderIndex the position of the variable's class in the order list
+	 * @return the upper bound for the order of the class on the given position of
+	 *         the order list
+	 */
+	protected double getUpperOrderBound(int orderSize, int orderIndex) {
+		if (orderIndex == -1) {
+			throw new IllegalArgumentException("Illegal order index provided.");
+		}
+		return (orderSize - orderIndex) * 1.0 / orderSize;
+	}
+
+	/**
+	 * Returns the lower bound for the order of the class on the given position of
+	 * the order list.
+	 * 
+	 * @param orderSize  the size of the order list, that is, the number of classes
+	 *                   (not object instances!) that are included in the SAT
+	 *                   genotype
+	 * @param orderIndex the position of the variable's class in the order list
+	 * @return the lower bound for the order of the class on the given position of
+	 *         the order list
+	 */
+	protected double getLowerOrderBound(int orderSize, int orderIndex) {
+		if (orderIndex == -1) {
+			throw new IllegalArgumentException("Illegal order index provided.");
+		}
+		return (orderSize - orderIndex - 1) * 1.0 / orderSize;
 	}
 
 	@Override

--- a/opendse-optimization/src/main/java/net/sf/opendse/optimization/SATCreatorDecoder.java
+++ b/opendse-optimization/src/main/java/net/sf/opendse/optimization/SATCreatorDecoder.java
@@ -55,8 +55,8 @@ public class SATCreatorDecoder extends AbstractSATDecoder<Genotype, Implementati
 	protected final Control control;
 
 	@Inject
-	public SATCreatorDecoder(VariableClassOrder order, SATManager manager, Rand random, SATConstraints constraints, SpecificationWrapper specificationWrapper,
-			Interpreter interpreter, Control control,
+	public SATCreatorDecoder(VariableClassOrder order, SATManager manager, Rand random, SATConstraints constraints,
+			SpecificationWrapper specificationWrapper, Interpreter interpreter, Control control,
 			@Constant(value = "variableorder", namespace = SATCreatorDecoder.class) boolean useVariableOrder) {
 		super(manager, random);
 		this.order = order;
@@ -73,13 +73,10 @@ public class SATCreatorDecoder extends AbstractSATDecoder<Genotype, Implementati
 			System.err.println("No feasible implementation exists.");
 			return new ImplementationWrapper(null);
 		}
-
 		model = constraints.decorate(model);
-
 		Specification specification = specificationWrapper.getSpecification();
 		Specification implementation = interpreter.toImplementation(specification, model);
 		ImplementationWrapper wrapper = new ImplementationWrapper(implementation);
-
 		return wrapper;
 	}
 
@@ -90,30 +87,69 @@ public class SATCreatorDecoder extends AbstractSATDecoder<Genotype, Implementati
 	}
 
 	@Override
-	public void randomize(Collection<Object> variables, Map<Object, Double> lowerBounds, Map<Object, Double> upperBounds,
-			Map<Object, Double> priorities, Map<Object, Boolean> phases) {
-
+	public void randomize(Collection<Object> variables, Map<Object, Double> lowerBounds,
+			Map<Object, Double> upperBounds, Map<Object, Double> priorities, Map<Object, Boolean> phases) {
+		// Iterates the encoding variables. Without preprocessing, these are the
+		// variables used for the formulation of the SAT constraints. With
+		// activated constraint preprocessing, the set of variables iterated
+		// here is potentially smaller and may consists of simplified variables.
 		for (Object variable : variables) {
-
+			// Sets the phases of the SAT-chromosomes during the randomized
+			// individual creation. If the phase is set to true, the
+			// corresponding variable will first be assigned to 1 during the
+			// constraint resolution by the SAT solver.
 			if (variable instanceof Resource) {
+				// The phase of a resource variable is initially set to 1 in 20
+				// % of all cases
 				phases.put(variable, random.nextDouble() < 0.2);
 			} else {
+				// All other variables are set randomly, i.e., they are set to 1
+				// in 50 % of all cases
 				phases.put(variable, random.nextDouble() < 0.5);
 			}
+			// The order genes of the SAT-genotypes correspond to the activity
+			// that the SAT-solver assigns to the variables during the
+			// constraint resolution. Variables with a HIGHER activity are set
+			// FIRST. Through application of the evolutionary operators during
+			// the optimization, the
+			// activity of each variable is varied between its lower and its
+			// upper bound. Yet, in this implementation, the different variable
+			// classes
+			// specified in the order-list are assigned to non-overlapping
+			// activity intervals. So, e.g., while the relative activity of
+			// different Resource-variables can change throughout the
+			// exploration, the assignment of all Resource-variables is ALWAYS
+			// done before (after) the assignment of all Link-variables if the
+			// Resource.class has a lower (higher) index in the order-list than
+			// the Link.class.
+
+			// The activity space between 0.0 and 1.0 is divided into n
+			// intervals of equal size, with n being the size of the order list.
+			// Each variable class is assigned to the interval corresponding to
+			// its position in the list.
+			// Example: With 5 variable classes in the order-list, the variable
+			// class at list position 1 is assigned the activity interval
+			// between
+			// .2 and .4
 			double lbv = (order.getOrderSize() - order.indexOf(variable) - 1) * 1.0 / order.getOrderSize();
 			double ubv = (order.getOrderSize() - order.indexOf(variable)) * 1.0 / order.getOrderSize();
 			double prio = lbv + random.nextDouble() * (ubv - lbv);
 			priorities.put(variable, prio);
 		}
-
 	}
 
 	@Override
 	public Set<Object> ignoreVariables(Set<Object> variables) {
+		// All variable classes that are not in the order list (the
+		// indexof()-method of the order list returns -1 in these cases) are
+		// ignored.
+		// While they remain part of the constraint system and are set during
+		// the constraint resolution, they are not part of the SAT-genotype and
+		// therefore: 1) Do not contribute to the growth of the search space and
+		// 2) can not be used by the optimizer to alter individuals.
 		Set<Object> ignore = super.ignoreVariables(variables);
 		for (Object object : variables) {
 			int index = order.indexOf(object);
-
 			if (index == -1) {
 				ignore.add(object);
 			}
@@ -124,26 +160,12 @@ public class SATCreatorDecoder extends AbstractSATDecoder<Genotype, Implementati
 	@Override
 	public Map<Object, Double> getLowerBounds(Set<Object> variables) {
 		Map<Object, Double> map = super.getLowerBounds(variables);
-
-		/*
-		 * for (Object var : variables) { int index = indexOf(var); assert
-		 * (index != -1);
-		 * 
-		 * double lower = order.size() - index - 1; map.put(var, lower); }
-		 */
-
 		return map;
 	}
 
 	@Override
 	public Map<Object, Double> getUpperBounds(Set<Object> variables) {
 		Map<Object, Double> map = this.getLowerBounds(variables);
-
-		/*
-		 * for (Object var : variables) { double value = map.get(var) + 1;
-		 * map.put(var, value); }
-		 */
-
 		return map;
 	}
 

--- a/opendse-optimization/src/main/java/net/sf/opendse/optimization/SATCreatorDecoder.java
+++ b/opendse-optimization/src/main/java/net/sf/opendse/optimization/SATCreatorDecoder.java
@@ -100,11 +100,9 @@ public class SATCreatorDecoder extends AbstractSATDecoder<Genotype, Implementati
 			} else {
 				phases.put(variable, random.nextDouble() < 0.5);
 			}
-
-			double lbv = ((double) order.indexOf(variable)) / order.getOrderSize();
-			double ubv = ((double) (1 + order.indexOf(variable))) / order.getOrderSize();
+			double lbv = (order.getOrderSize() - order.indexOf(variable) - 1) * 1.0 / order.getOrderSize();
+			double ubv = (order.getOrderSize() - order.indexOf(variable)) * 1.0 / order.getOrderSize();
 			double prio = lbv + random.nextDouble() * (ubv - lbv);
-			// System.out.println(variable+" "+prio);
 			priorities.put(variable, prio);
 		}
 

--- a/opendse-optimization/src/test/java/net/sf/opendse/optimization/SATCreatorDecoderTest.java
+++ b/opendse-optimization/src/test/java/net/sf/opendse/optimization/SATCreatorDecoderTest.java
@@ -1,0 +1,77 @@
+package net.sf.opendse.optimization;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.opt4j.core.common.random.Rand;
+import org.opt4j.core.optimizer.Control;
+import org.opt4j.satdecoding.SATManager;
+
+import net.sf.opendse.optimization.encoding.Interpreter;
+
+import static org.mockito.Mockito.mock;
+
+
+public class SATCreatorDecoderTest {
+
+	protected SATCreatorDecoder getObject() {
+		VariableClassOrder order = mock(VariableClassOrder.class);
+		SATManager manager = mock(SATManager.class);
+		Rand random = mock(Rand.class);
+		SATConstraints constraints = mock(SATConstraints.class);
+		SpecificationWrapper specificationWrapper = mock(SpecificationWrapper.class);
+		Interpreter interpreter = mock(Interpreter.class);
+		Control control = mock(Control.class);
+		SATCreatorDecoder result = new SATCreatorDecoder(order, manager, random, constraints, specificationWrapper, interpreter, control, true);
+		return result;
+	}
+	
+	@Test
+	public void testBoundsDefault() {
+		// default case: only object is in the list
+		int orderSize = 1;
+		int orderIndex = 0;
+		SATCreatorDecoder testObject = getObject();
+		assertEquals(0.0, testObject.getLowerOrderBound(orderSize, orderIndex), 0.0);
+		assertEquals(1.0, testObject.getUpperOrderBound(orderSize, orderIndex), 0.0);
+	}
+	
+	@Test
+	public void testBoundsFiveEntries() {
+		// five entries in the list
+		int orderSize = 5;
+		SATCreatorDecoder testObject = getObject();
+		assertEquals(0.8, testObject.getLowerOrderBound(orderSize, 0), 0.0);
+		assertEquals(1.0, testObject.getUpperOrderBound(orderSize, 0), 0.0);
+		
+		assertEquals(0.6, testObject.getLowerOrderBound(orderSize, 1), 0.0);
+		assertEquals(0.8, testObject.getUpperOrderBound(orderSize, 1), 0.0);
+		
+		assertEquals(0.4, testObject.getLowerOrderBound(orderSize, 2), 0.0);
+		assertEquals(0.6, testObject.getUpperOrderBound(orderSize, 2), 0.0);
+		
+		assertEquals(0.2, testObject.getLowerOrderBound(orderSize, 3), 0.0);
+		assertEquals(0.4, testObject.getUpperOrderBound(orderSize, 3), 0.0);
+		
+		assertEquals(0.0, testObject.getLowerOrderBound(orderSize, 4), 0.0);
+		assertEquals(0.2, testObject.getUpperOrderBound(orderSize, 4), 0.0);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testIgnoredVariable1() {
+		// five entries, but variable ignored
+		int orderSize = 5;
+		int orderIndex = -1;
+		SATCreatorDecoder testObject = getObject();
+		testObject.getLowerOrderBound(orderSize, orderIndex);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testIgnoredVariable2() {
+		// five entries, but variable ignored
+		int orderSize = 5;
+		int orderIndex = -1;
+		SATCreatorDecoder testObject = getObject();
+		testObject.getUpperOrderBound(orderSize, orderIndex);
+	}
+}


### PR DESCRIPTION
In the current state, we provide the desired SAT solution strategy by a list that is referred to as the order. I think that it is intuitive to assume that the things that come first in the list are set first (and we also create the default variable order in this way).

However, the SAT4J API uses activity instead of the order of the variables and the variables with the HIGHEST activity are set FIRST. So, in the current state, the variables that we provide on the last positions of the list are set first.

We can address this issue by either changing the documentation or the code. I find it intuitive to directly provide the solving order by a list of variables where the first variable type is set first and so forth, so I suggest to alter the code as proposed by this PR.